### PR TITLE
Fix trouble on display code for readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ JavaScript that users can simply reference from the TypeScript compiler using a 
 
    Programmatically:
 
-   ```js
+```js
 require('dts-generator').generate({
 	name: 'package-name',
 	baseDir: '/path/to/package-directory',
@@ -39,13 +39,13 @@ require('dts-generator').generate({
 
    Command-line:
 
-   ```bash
+```bash
 dts-generator --name package-name --baseDir /path/to/package-directory --out package-name.d.ts a.ts b.ts ...
 ```
 
    Grunt:
 
-   ```js
+```js
 module.exports = function (grunt) {
 	grunt.loadNpmTasks('dts-generator');
 	grunt.initConfig({
@@ -65,7 +65,7 @@ module.exports = function (grunt) {
 
 3. Reference your generated d.ts bundle from somewhere in your consumer module and import away!:
 
-   ```ts
+```ts
 /// <reference path="typings/package-name.d.ts" />
 
 import Foo = require('package-name/Foo');


### PR DESCRIPTION
Code zone are not display correctly due to invalid indentation.
![image](https://cloud.githubusercontent.com/assets/3797978/25132485/0d18b64a-244a-11e7-860c-484ba0a363db.png)
Now fix
![image](https://cloud.githubusercontent.com/assets/3797978/25132505/1afcb950-244a-11e7-9840-0dc103290057.png)
